### PR TITLE
Adding Bandit parser to Lintly

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Now you will see a review with linting errors...
     ```
     $ stylelint . | lintly --format=stylelint
     ```
+- [bandit](https://github.com/PyCQA/bandit)
+    ```
+    $ bandit -r . --format=json | lintly --format=bandit-json
+    ```
 
 - [cfn-lint](https://github.com/aws-cloudformation/cfn-python-lint)
     ```

--- a/lintly/parsers.py
+++ b/lintly/parsers.py
@@ -234,6 +234,77 @@ class CfnLintParser(BaseLintParser):
         return violations
 
 
+class BanditJSONParser(BaseLintParser):
+    """
+    Bandit JSON format:
+
+      [
+          {
+              "errors": [],
+              "generated_at": "2021-01-07T23:39:39Z",
+              "metrics": {
+                  "./lintly/formatters.py": {
+                      "CONFIDENCE.HIGH": 1.0,
+                      "CONFIDENCE.LOW": 0.0,
+                      "CONFIDENCE.MEDIUM": 0.0,
+                      "CONFIDENCE.UNDEFINED": 0.0,
+                      "SEVERITY.HIGH": 1.0,
+                      "SEVERITY.LOW": 0.0,
+                      "SEVERITY.MEDIUM": 0.0,
+                      "SEVERITY.UNDEFINED": 0.0,
+                      "loc": 31,
+                      "nosec": 0
+                      },
+              "results": [
+                  {
+                      "code": "13 \n14 env = Environment(\n15 loader=FileSystemLoader(TEMPLATES_PATH),
+                                  \n16 autoescape=False\n17 )\n",
+                      "filename": "./lintly/formatters.py",
+                      "issue_confidence": "HIGH",
+                      "issue_severity": "HIGH",
+                      "issue_text": "Using jinja2 templates with autoescape=False is dangerous and can lead to XSS."
+                                    "Use autoescape=True or use the select_autoescape function.",
+                      "line_number": 14,
+                      "line_range": [
+                          14,
+                          15,
+                          16
+                          ],
+                     "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b701_jinja2_autoescape_false.html",
+                     "test_id": "B701"
+                     "test_name": "jinja2_autoescape_false"
+                }
+            ]
+         }
+     ]
+
+    """
+
+    def parse_violations(self, output):
+
+        output = output.strip()
+        if not output:
+            return dict()
+
+        json_data = json.loads(output)
+
+        violations = collections.defaultdict(list)
+        for violation_json in json_data["results"]:
+            violation = Violation(
+                line=violation_json["line_number"],
+                column=0,
+                code="{} ({})".format(
+                    violation_json["test_id"], violation_json["test_name"]
+                ),
+                message=violation_json["issue_text"],
+            )
+
+            path = self._normalize_path(violation_json["filename"])
+            violations[path].append(violation)
+
+        return violations
+
+
 class CfnNagParser(BaseLintParser):
 
     def parse_violations(self, output):
@@ -293,6 +364,9 @@ PARSERS = {
 
     # cfn-lint default formatter
     'cfn-lint': CfnLintParser(),
+
+    # Bandit Parser
+    "bandit-json": BanditJSONParser(),
 
     # cfn-nag JSON output
     'cfn-nag': CfnNagParser(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Jinja2<3.0
 PyGithub<2.0
 cached-property<2.0
 ci-py
-click<7.0
+click<8.0
 codecov
 coverage
 flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ coverage
 flake8
 mock
 pytest
-python-gitlab<2.0
+python-gitlab<3.0
 tox

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ dependencies = [
     'click<8.0',
     'Jinja2<3.0',
     'PyGithub<2.0',
-    'python-gitlab<2.0',
+    'python-gitlab<3.0',
     'six',
 ]
 

--- a/tests/linters_output/bandit-json.txt
+++ b/tests/linters_output/bandit-json.txt
@@ -1,0 +1,120 @@
+{
+  "errors": [],
+  "generated_at": "2021-01-07T23:39:39Z",
+  "metrics": {
+    "./lintly/formatters.py": {
+      "CONFIDENCE.HIGH": 1.0,
+      "CONFIDENCE.LOW": 0.0,
+      "CONFIDENCE.MEDIUM": 0.0,
+      "CONFIDENCE.UNDEFINED": 0.0,
+      "SEVERITY.HIGH": 1.0,
+      "SEVERITY.LOW": 0.0,
+      "SEVERITY.MEDIUM": 0.0,
+      "SEVERITY.UNDEFINED": 0.0,
+      "loc": 31,
+      "nosec": 0
+    },
+    "_totals": {
+      "CONFIDENCE.HIGH": 6.0,
+      "CONFIDENCE.LOW": 0.0,
+      "CONFIDENCE.MEDIUM": 0.0,
+      "CONFIDENCE.UNDEFINED": 0.0,
+      "SEVERITY.HIGH": 2.0,
+      "SEVERITY.LOW": 4.0,
+      "SEVERITY.MEDIUM": 0.0,
+      "SEVERITY.UNDEFINED": 0.0,
+      "loc": 2596,
+      "nosec": 0
+    }
+  },
+  "results": [
+    {
+      "code": "13 \n14 env = Environment(\n15     loader=FileSystemLoader(TEMPLATES_PATH),\n16     autoescape=False\n17 )\n",
+      "filename": "./build/lib/lintly/formatters.py",
+      "issue_confidence": "HIGH",
+      "issue_severity": "HIGH",
+      "issue_text": "Using jinja2 templates with autoescape=False is dangerous and can lead to XSS. Use autoescape=True or use the select_autoescape function to mitigate XSS vulnerabilities.",
+      "line_number": 14,
+      "line_range": [
+        14,
+        15,
+        16
+      ],
+      "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b701_jinja2_autoescape_false.html",
+      "test_id": "B701",
+      "test_name": "jinja2_autoescape_false"
+    },
+    {
+      "code": "13 \n14 env = Environment(\n15     loader=FileSystemLoader(TEMPLATES_PATH),\n16     autoescape=False\n17 )\n",
+      "filename": "./lintly/formatters.py",
+      "issue_confidence": "HIGH",
+      "issue_severity": "HIGH",
+      "issue_text": "Using jinja2 templates with autoescape=False is dangerous and can lead to XSS. Use autoescape=True or use the select_autoescape function to mitigate XSS vulnerabilities.",
+      "line_number": 14,
+      "line_range": [
+        14,
+        15,
+        16
+      ],
+      "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b701_jinja2_autoescape_false.html",
+      "test_id": "B701",
+      "test_name": "jinja2_autoescape_false"
+    },
+    {
+      "code": "47     builds.LintlyBuild(config, \"Some linter output\")\n48     assert GitHubBackend.call_args[1][\"context\"] == format_and_context[2]\n",
+      "filename": "./tests/test_builds.py",
+      "issue_confidence": "HIGH",
+      "issue_severity": "LOW",
+      "issue_text": "Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "line_number": 48,
+      "line_range": [
+        48
+      ],
+      "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b101_assert_used.html",
+      "test_id": "B101",
+      "test_name": "assert_used"
+    },
+    {
+      "code": "12     result = runner.invoke(cli.main, ['--help'])\n13     assert result.exit_code == 0\n14     assert not result.exception\n",
+      "filename": "./tests/test_cli.py",
+      "issue_confidence": "HIGH",
+      "issue_severity": "LOW",
+      "issue_text": "Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "line_number": 13,
+      "line_range": [
+        13
+      ],
+      "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b101_assert_used.html",
+      "test_id": "B101",
+      "test_name": "assert_used"
+    },
+    {
+      "code": "13     assert result.exit_code == 0\n14     assert not result.exception\n15     assert 'Usage' in result.output\n",
+      "filename": "./tests/test_cli.py",
+      "issue_confidence": "HIGH",
+      "issue_severity": "LOW",
+      "issue_text": "Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "line_number": 14,
+      "line_range": [
+        14
+      ],
+      "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b101_assert_used.html",
+      "test_id": "B101",
+      "test_name": "assert_used"
+    },
+    {
+      "code": "14     assert not result.exception\n15     assert 'Usage' in result.output\n16 \n",
+      "filename": "./tests/test_cli.py",
+      "issue_confidence": "HIGH",
+      "issue_severity": "LOW",
+      "issue_text": "Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "line_number": 15,
+      "line_range": [
+        15
+      ],
+      "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b101_assert_used.html",
+      "test_id": "B101",
+      "test_name": "assert_used"
+    }
+  ]
+}

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -93,6 +93,39 @@ class Flake8ParserTestCase(ParserTestCaseMixin, unittest.TestCase):
     }
 
 
+class BanditJSONParserTestCase(ParserTestCaseMixin, unittest.TestCase):
+    parser = PARSERS['bandit-json']
+    linter_output_file_name = 'bandit-json.txt'
+    expected_violations = {
+        'build/lib/lintly/formatters.py': [
+            {'line': 14, 'column': 0, 'code': 'B701 (jinja2_autoescape_false)',
+             'message': ('Using jinja2 templates with autoescape=False is dangerous and can lead to XSS. '
+                         'Use autoescape=True or use the select_autoescape function to mitigate XSS vulnerabilities.')}
+        ],
+        'lintly/formatters.py': [
+            {'line': 14, 'column': 0, 'code': 'B701 (jinja2_autoescape_false)',
+             'message': ('Using jinja2 templates with autoescape=False is dangerous and can lead to XSS. '
+                         'Use autoescape=True or use the select_autoescape function to mitigate XSS vulnerabilities.')}
+        ],
+        'tests/test_builds.py': [
+            {'line': 48, 'column': 0, 'code': 'B101 (assert_used)',
+             'message': ('Use of assert detected. '
+                         'The enclosed code will be removed when compiling to optimised byte code.')}
+        ],
+        'tests/test_cli.py': [
+            {'line': 13, 'column': 0, 'code': 'B101 (assert_used)',
+             'message': ('Use of assert detected. '
+                         'The enclosed code will be removed when compiling to optimised byte code.')},
+            {'line': 14, 'column': 0, 'code': 'B101 (assert_used)',
+             'message': ('Use of assert detected. '
+                         'The enclosed code will be removed when compiling to optimised byte code.')},
+            {'line': 15, 'column': 0, 'code': 'B101 (assert_used)',
+             'message': ('Use of assert detected. '
+                         'The enclosed code will be removed when compiling to optimised byte code.')}
+        ]
+    }
+
+
 class PylintJSONParserTestCase(ParserTestCaseMixin, unittest.TestCase):
     parser = PARSERS['pylint-json']
     linter_output_file_name = 'pylint-json.txt'


### PR DESCRIPTION
Enhances Lintly to support Bandit-python scanner.

